### PR TITLE
Post OTIO core 0.17.0 release cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           if [[ "${{ matrix.otio-version }}" == "main" ]]; then
             pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git"
           else
-            pip install OpenTimelineIO>=${{ matrix.otio-version }} --pre --only-binary :all:
+            pip install OpenTimelineIO>=${{ matrix.otio-version }} --only-binary :all:
           fi
           pip install flake8 pytest pytest-cov
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,14 +22,11 @@ jobs:
 
     strategy:
       matrix:
+        # Use macos-13 so we'll be on intel hardware and can pull a pre-built wheel
+        # When OTIO has an Apple Silicon build we can switch back to macos-latest for that version
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
         otio-version: [ "0.17.0", "main" ]
-        exclude:
-          - { os: macos-latest, python-version: 3.7 }
-          - { os: macos-latest, python-version: 3.8 }
-          - { os: macos-latest, python-version: 3.9 }
-
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,11 @@ jobs:
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         otio-version: [ "0.17.0", "main" ]
+        exclude:
+          - { os: macos-latest, python-version: 3.7 }
+          - { os: macos-latest, python-version: 3.8 }
+          - { os: macos-latest, python-version: 3.9 }
+
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file="LICENSE" }
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "opentimelineio >= 0.17.0.dev1"
+    "opentimelineio >= 0.17.0"
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "otio-fcpx-xml-adapter"
-version = "1.0.0"
+version = "1.1.0"
 description = "OpenTimelineIO FCP X XML Adapter"
 authors = [
   { name="Contributors to the OpenTimelineIO project", email="otio-discussion@lists.aswf.io" },


### PR DESCRIPTION
* remove `--pre` flag from ci.yaml
* set OTIO version dependency to 0.17.0 in pyproject.toml

> **NOTE!** this is expected to fail in CI until the 0.17.0 release of OTIO core is out